### PR TITLE
Update sip.go to correctly mark truncated SIP packets

### DIFF
--- a/layers/sip.go
+++ b/layers/sip.go
@@ -262,6 +262,9 @@ func (s *SIP) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
 		line, err = buffer.ReadBytes(byte('\n'))
 		if err != nil {
 			if err == io.EOF {
+				if len(bytes.Trim(line, "\r\n")) > 0 {
+					df.SetTruncated()
+				}
 				break
 			} else {
 				return err


### PR DESCRIPTION
Changed the decodeFromBytes() to mark SIP packets as truncated, if the parser hits a line that is not terminated by a CR-LF.